### PR TITLE
Migrate from structopt to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
 dependencies = [
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -114,17 +154,6 @@ name = "atree"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "132573478eb9ff973c6f75d0ed425ac12da77d266506483345f46743ecc83a98"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -336,13 +365,13 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "c2pa",
+ "clap",
  "env_logger",
  "log",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
- "structopt",
  "tempfile",
 ]
 
@@ -403,18 +432,45 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "2686c4115cb0810d9a984776e197823d08ec94f176549a89a9efded477c456dc"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e53afce1efce6ed1f633cf0e57612fe51db54a1ee4fd8f8503d078fe02d69ae"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.12",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -431,6 +487,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console_log"
@@ -924,21 +986,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -1565,30 +1615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,33 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2079,15 +2081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2241,12 +2234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2285,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,12 +2306,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0" }
-structopt = "0.3"
+clap = { versiom = "4.3", features = [ "derive" ] }
 tempfile = "3.6"
 regex = "1.8.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ repository = "https://github.com/contentauth/c2pa-attacks"
 [dependencies]
 anyhow = "1.0"
 c2pa = { version = "0.23.2", features = ["fetch_remote_manifests", "file_io", "xmp_write"] }
+clap = { versiom = "4.3", features = ["derive"] }
 env_logger = "0.10"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0" }
-clap = { versiom = "4.3", features = [ "derive" ] }
 tempfile = "3.6"
 regex = "1.8.4"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,13 @@ use c2pa::{
     assertions::{labels, CreativeWork, SchemaDotOrgPerson},
     Error, Manifest, ManifestStore, ManifestStoreReport,
 };
+use clap::Parser;
+
 /// Tool to display and create C2PA security testing content
 ///
 /// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg -f -t author -a ./attacks/xss.txt
 use regex::Regex;
 use serde_json::{Map, Value};
-use structopt::{clap::AppSettings, StructOpt};
 
 mod signer;
 use serde::Deserialize;
@@ -46,70 +47,64 @@ struct ManifestDef {
 }
 
 // define the command line options
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Tool for creating C2PA manifests for security testing.",global_settings = &[AppSettings::ColoredHelp, AppSettings::ArgRequiredElseHelp])]
+#[derive(Parser, Debug)]
+#[command(
+    name = "c2pa-attacks",
+    about = "A tool that can create C2PA manifests for the purposes of security testing."
+)]
 struct CliArgs {
-    #[structopt(parse(from_os_str))]
-    #[structopt(
-        short = "m",
-        long = "manifest_file",
-        help = "Path to manifest definition JSON file."
-    )]
+    /// The path for the original asset image
+    #[arg(required = true)]
+    path: PathBuf,
+
+    /// Path to manifest definition JSON file
+    #[arg(short = 'm', required = true)]
     manifest_file: Option<PathBuf>,
 
-    #[structopt(parse(from_os_str))]
-    #[structopt(short = "o", long = "output", help = "Path to output file or folder.")]
+    /// Path to the output folder and base file name for the output
+    #[arg(short = 'o', required = true)]
     output: Option<PathBuf>,
 
-    #[structopt(parse(from_os_str))]
-    #[structopt(short = "p", long = "parent", help = "Path to a parent file.")]
-    parent: Option<PathBuf>,
-
-    #[structopt(
-        short = "c",
-        long = "config",
-        help = "Manifest definition passed as a JSON string."
-    )]
-    config: Option<String>,
-
-    #[structopt(
-        short = "d",
-        long = "detailed",
-        help = "Display detailed C2PA-formatted manifest data."
-    )]
-    detailed: bool,
-
-    #[structopt(
-        short = "v",
-        long = "verbose",
-        help = "Display C2PA-formatted manifest data."
-    )]
-    verbose: bool,
-
-    #[structopt(
-        short = "f",
-        long = "force",
-        help = "Force overwrite of output if it already exists."
-    )]
-    force: bool,
-
-    #[structopt(
-        short = "t",
-        long = "target",
-        help = "The target field to replace. ['author','title','format','label','vendor','person_identifier','instance_id']"
+    /// The target field to replace or indicating the use of regex mode
+    #[arg(
+        short = 't',
+        required = true,
+        value_parser = clap::builder::PossibleValuesParser::new([
+        "author",
+        "title",
+        "format",
+        "label",
+        "vendor",
+        "person_identifier",
+        "instance_id",
+        "claim_generator",
+        "regex"])
     )]
     target: Option<String>,
 
-    #[structopt(
-        short = "a",
-        long = "attack_file",
-        help = "The file containing the attack strings to use."
-    )]
+    /// The file containing the attack strings to use
+    #[arg(short = 'a', required = true)]
     attack_file: String,
 
-    /// The path to an asset to examine or embed a manifest into.
-    #[structopt(parse(from_os_str))]
-    path: PathBuf,
+    /// Path to a parent file
+    #[arg(short = 'p')]
+    parent: Option<PathBuf>,
+
+    /// Manifest definition passed as a JSON string
+    #[arg(short = 'c')]
+    config: Option<String>,
+
+    /// Display detailed C2PA-formatted manifest data
+    #[arg(short = 'd')]
+    detailed: bool,
+
+    /// Force overwriting of any pre-existing output files
+    #[arg(short = 'f')]
+    force: bool,
+
+    /// Display verbose output
+    #[arg(short = 'v')]
+    verbose: bool,
 }
 
 /**
@@ -366,7 +361,7 @@ fn create_manifest_def(
 }
 
 fn main() -> Result<()> {
-    let mut args = CliArgs::from_args();
+    let mut args = CliArgs::parse();
 
     // set RUST_LOG=debug to get detailed debug logging
     if std::env::var("RUST_LOG").is_err() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@
 /// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks \
 /// ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg \
 /// -f -t author -a ./attacks/xss.txt
-///
 use std::{
     collections::HashMap,
     fs::{create_dir_all, File},

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,10 @@
 // each license.
 
 #![doc = include_str!("../README.md")]
+/// Tool to display and create C2PA security testing content
+///
+/// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg -f -t author -a ./attacks/xss.txt
+///
 use std::{
     collections::HashMap,
     fs::{create_dir_all, File},
@@ -24,10 +28,6 @@ use c2pa::{
     Error, Manifest, ManifestStore, ManifestStoreReport,
 };
 use clap::Parser;
-
-/// Tool to display and create C2PA security testing content
-///
-/// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg -f -t author -a ./attacks/xss.txt
 use regex::Regex;
 use serde_json::{Map, Value};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,9 @@
 #![doc = include_str!("../README.md")]
 /// Tool to display and create C2PA security testing content
 ///
-/// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg -f -t author -a ./attacks/xss.txt
+/// Example command: ./target/x86_64-apple-darwin/release/c2pa-attacks \
+/// ./sample/C.jpg  -m ./sample/test.json -o ./sample_out/C_mod.jpg \
+/// -f -t author -a ./attacks/xss.txt
 ///
 use std::{
     collections::HashMap,
@@ -125,8 +127,8 @@ fn report_from_path<P: AsRef<Path>>(path: &P, is_detailed: bool) -> Result<Strin
     })
 }
 
-/// The file containing the injection attacks needs to be read line-by-line
-/// This will return an Iterator to the Reader of the lines of the file.
+// The file containing the injection attacks needs to be read line-by-line
+// This will return an Iterator to the Reader of the lines of the file.
 fn read_lines<P>(filename: P) -> io::Result<io::Lines<io::BufReader<File>>>
 where
     P: AsRef<Path>,
@@ -135,11 +137,11 @@ where
     Ok(io::BufReader::new(file).lines())
 }
 
-/// Malicious strings may have double quotes or backslashes that need to be escaped for the JSON manifest. This function will take the injection string and escape any backslashes or double quotes that might be mistakenly interpreted by JSON.
-///
-/// A trailing backslash needs to be escaped because it may be the last character in the string causing the double quote terminating the string to be escaped. Double quotes need to be escaped because they will conflict with existing JSON double quotes.
-///
-/// This returns the injection string with the appropriate characters escaped.
+// Malicious strings may have double quotes or backslashes that need to be escaped for the JSON manifest. This function will take the injection string and escape any backslashes or double quotes that might be mistakenly interpreted by JSON.
+//
+// A trailing backslash needs to be escaped because it may be the last character in the string causing the double quote terminating the string to be escaped. Double quotes need to be escaped because they will conflict with existing JSON double quotes.
+//
+// This returns the injection string with the appropriate characters escaped.
 fn escape_malicious_string(mal_string: String) -> Result<String> {
     // First escape any ending backslashes
     // Only escape if the last backslash isn't already escaped.
@@ -204,7 +206,8 @@ fn remove_existing_assertion(
     new_json
 }
 
-/// For attack types of author or person_identifier, we will create a new malicious Creative Work assertion with the appropriate malicous fields.
+// For attack types of author or person_identifier, we will create a new malicious
+// Creative Work assertion with the appropriate malicous fields.
 fn malicious_creative_work(
     field_type: String,
     mal_string: &mut String,
@@ -235,13 +238,13 @@ fn malicious_creative_work(
     Ok(new_creative_work)
 }
 
-/// This function will create the malicious output files.
-///
-/// The output files are of the format:
-///
-/// {targeted_field}_{line_no_from_injection_file}_{original_name_of_input_file}
-///
-/// The line numbers from the injection file start at zero.
+// This function will create the malicious output files.
+//
+// The output files are of the format:
+//
+// {targeted_field}_{line_no_from_injection_file}_{original_name_of_input_file}
+//
+// The line numbers from the injection file start at zero.
 fn output_file(
     args: &mut CliArgs,
     manifest: &mut Manifest,


### PR DESCRIPTION
## Changes in this pull request
The structopt library has not been updated in some time. This code change migrates to clap command line parser which is currently updated and matches the c2patool implementation. This addresses issue #12 .

## Checklist
- [ X] This PR represents a single feature, fix, or change.
- [ X] All applicable changes have been documented.
- [ X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
