### PR TITLE
Address clippy issue regarding flatten usage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -500,7 +500,7 @@ fn main() -> Result<()> {
     // If we can successfully read the injection file path
     if let Ok(lines) = read_lines(args.attack_file.clone()) {
         // Consumes the iterator, returns an (Optional) String
-        for mal_string in lines.flatten() {
+        for mal_string in lines.map_while(Result::ok) {
             let result = create_file(
                 field_type.clone(),
                 &mut loop_index,


### PR DESCRIPTION
## Changes in this pull request
This is to address the following clippy error:
```
note: this expression returning a `std::io::Lines` may produce an infinite number of `Err` in case of a read error
   --> src/main.rs:503:27
    |
503 |         for mal_string in lines.flatten() {
    |                           ^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#lines_filter_map_ok
```

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
