### PR TITLE
Migrate off actions-rs/toolchain since it is archived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: ${{ matrix.rust_version }}
           # components: llvm-tools-preview
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
           override: true
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           override: true
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           override: true
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       # - name: Install cargo-llvm-cov
       #   uses: taiki-e/install-action@cargo-llvm-cov
@@ -67,7 +67,7 @@ jobs:
         run: rustup component add clippy
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2
 
       - name: Cargo clippy
         uses: actions-rs/clippy-check@v1


### PR DESCRIPTION
This is the first test with v1 of the dtolnay version of the toolchain to see if it is sufficient. However, nightly may be required due to https://github.com/rust-lang/rust/issues/130323 Also, upgrading rust-cache version.

## Changes in this pull request
Migration from actions-rs/toolchain to dtolnay/rust-toolchain since actions-rs has been archived.

## Checklist
- [ X ] This PR represents a single feature, fix, or change.
- [ X ] All applicable changes have been documented.
- [ X ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
