### PR TITLE
Convert deny to version 2

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,6 +3,7 @@
 # For further details on all configuration options see:
 # https://embarkstudios.github.io/cargo-deny/checks/cfg.html
 
+[graph]
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "x86_64-apple-darwin" },

--- a/deny.toml
+++ b/deny.toml
@@ -13,10 +13,7 @@ targets = [
 
 # Deny all advisories unless explicitly ignored.
 [advisories]
-vulnerability = "deny"
-unmaintained = "deny"
-yanked = "deny"
-notice = "deny"
+version = 2
 
 ignore = [
   "RUSTSEC-2020-0071", # time 0.1.45 (see https://github.com/indygreg/cryptography-rs/issues/10)
@@ -31,6 +28,8 @@ wildcards = "allow"
 
 # List of allowed licenses.
 [licenses]
+version = 2
+confidence-threshold = 0.8
 allow = [
   "Apache-2.0",
   "BSD-2-Clause",
@@ -43,9 +42,6 @@ allow = [
   "Unicode-DFS-2016",
   "Zlib",
 ]
-copyleft = "deny"
-unlicensed = "deny"
-confidence-threshold = 0.8
 
 [[licenses.clarify]]
 name = "ring"


### PR DESCRIPTION
According to https://github.com/EmbarkStudios/cargo-deny/pull/611 , these fields have been deprecated and can be replaced with version = 2.

## Changes in this pull request
Deprecated fields have been removed and replaced with version = 2.

## Checklist
- [ X ] This PR represents a single feature, fix, or change.
- [ X ] All applicable changes have been documented.
- [ X ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
