### PR TITLE
Fix c2patool link

### DIFF
--- a/docs/appendix.md
+++ b/docs/appendix.md
@@ -4,7 +4,7 @@
 
 The "c2patool" is a good complimentary tool for inspecting the files created by this tool: [https://github.com/contentauth/c2pa-rs/tree/main/cli](https://github.com/contentauth/c2pa-rs/tree/main/cli).
 
-Technical specifications for C2PA standard assertions including JSON samples: <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_c2pa_standard_assertions>.
+Technical specifications for C2PA standard assertions including JSON samples: [https://spec.c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_c2pa_standard_assertions](https://spec.c2pa.org/specifications/specifications/2.2/specs/C2PA_Specification.html#_c2pa_standard_assertions).
 
 ## Injection string references
 


### PR DESCRIPTION
## Changes in this pull request
Fixes the link to the c2patool

## Checklist
- [ X ] This PR represents a single feature, fix, or change.
- [ X ] All applicable changes have been documented.
- [ X ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
