### PR TITLE
Update signer.rs to address Clippy redundancy error

### DIFF
--- a/src/signer.rs
+++ b/src/signer.rs
@@ -72,7 +72,7 @@ impl SignConfig {
 
         if let Some(path) = self.private_key.as_deref() {
             private_key =
-                Some(std::fs::read(path).context(format!("Reading private key: {:?}", &path))?);
+                Some(std::fs::read(path).context(format!("Reading private key: {:?}", path))?);
         }
 
         if private_key.is_none() {
@@ -83,7 +83,7 @@ impl SignConfig {
 
         if let Some(path) = self.sign_cert.as_deref() {
             sign_cert =
-                Some(std::fs::read(path).context(format!("Reading sign cert: {:?}", &path))?);
+                Some(std::fs::read(path).context(format!("Reading sign cert: {:?}", path))?);
         }
 
         if sign_cert.is_none() {


### PR DESCRIPTION
Clippy is flagging the "&" as redundant. Attempting to remove.

## Changes in this pull request
Clippy is flagging the "&" in "&path" as redundant. This pull request attempts to remove it in order to make Clippy happy.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
